### PR TITLE
Update README for SpotX-Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@
 
 **UPDATE 2: Fixed to run on latest version. Contributed by @ptest13243546**
 
-**UPDATE 3: Not currently being maintained. Please check [SpotX](https://github.com/SpotX-CLI/SpotX-Mac)**
+**UPDATE 3: Not currently being maintained. Please check [SpotX-Bash](https://github.com/jetfir3/SpotX-Bash)**


### PR DESCRIPTION
Updated the SpotX hyperlink in the README. 

The SpotX-Mac repo (and CLI organization) is a shell of what it once was and hasn't been updated to support a newer build in over 6 months. At that time, I left the organization and continued the project under my own account and have merged Linux and macOS into a single SpotX-Bash repo @ https://github.com/jetfir3/SpotX-Bash



